### PR TITLE
Multiselect props update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/sphere-ui",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "main": "dist/index.js",
   "license": "MIT",
   "repository": "https://github.com/Cado-Labs/sphere-ui",

--- a/src/components/MultiSelect/index.js
+++ b/src/components/MultiSelect/index.js
@@ -29,7 +29,6 @@ export const MultiSelect = React.forwardRef(({
   id = null,
   disabled = false,
   showClear = false,
-  removeIcon = false,
 }, ref) => {
   const multiselectRef = useRef(ref)
 
@@ -53,6 +52,10 @@ export const MultiSelect = React.forwardRef(({
     const isFunction = optionDisabled instanceof Function
 
     return isFunction ? optionDisabled() : optionDisabled
+  }
+
+  const removeIcon = () => {
+    return isOptionDisabled() ? false : "pi pi-times-circle"
   }
 
   const renderHeader = () => {
@@ -109,7 +112,7 @@ export const MultiSelect = React.forwardRef(({
       selectedItemsLabel={selectedItemsLabel}
       showClear={showClear}
       display={display}
-      removeIcon={removeIcon}
+      removeIcon={removeIcon()}
     />
   )
 })

--- a/storybook/i18n/locales/stories/multiselect/en.yml
+++ b/storybook/i18n/locales/stories/multiselect/en.yml
@@ -24,4 +24,3 @@ props:
   selectedItemsLabel: Function that gets an item in the value and returns the content for it.
   showClear: Displays an icon to clear the value.
   display: Used mode to display the selected item. Valid values are 'comma' and 'chip'.
-  removeIcon: Icon of the remove chip element.

--- a/storybook/stories/form/MultiSelect/multiSelect.js
+++ b/storybook/stories/form/MultiSelect/multiSelect.js
@@ -65,7 +65,6 @@ export const multiSelect = {
     { name: "selectedItemsLabel", type: "string", description: `${I18N_PREFIX}.props.selectedItemsLabel` },
     { name: "showClear", type: "boolean", default: false, description: `${I18N_PREFIX}.props.showClear` },
     { name: "display", type: "string", description: `${I18N_PREFIX}.props.display` },
-    { name: "removeIcon", type: "any", default: false, description: `${I18N_PREFIX}.props.removeIcon` },
   ],
   eventDescriptionProps: [
     { name: "onChange", params: onChangeParams, description: `${I18N_PREFIX}.props.onChange` },


### PR DESCRIPTION
* Changed removeItem props

For unification, it is better not to allow the enter of different types of icons and it is better to remove the icon inside the multiselect component, based on the props disabled