### PR TITLE
Fix Dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/sphere-ui",
-  "version": "5.0.0-beta.2",
+  "version": "5.0.0",
   "main": "dist/index.js",
   "license": "MIT",
   "repository": "https://github.com/Cado-Labs/sphere-ui",

--- a/src/components/Dialog/index.js
+++ b/src/components/Dialog/index.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect } from "react"
 import { Dialog as PrimeDialog } from "primereact/dialog"
 
 import { pickDataAttributes } from "../../utils"
@@ -19,9 +19,21 @@ export const Dialog = React.forwardRef(({
   breakpoints,
   onClick,
   onMaskClick,
+  blockScroll = true,
+  maximizable = false,
+  keepInViewport = true,
+  maximized = false,
+  dismissableMask = true,
+  modal = true,
   children,
   ...props
 }, ref) => {
+  useEffect(() => {
+    return () => {
+      document.body.classList.remove("p-overflow-hidden")
+    }
+  })
+
   const dataAttributes = pickDataAttributes(props)
   return (
     <PrimeDialog
@@ -43,15 +55,15 @@ export const Dialog = React.forwardRef(({
       onMaskClick={onMaskClick}
       draggable={false}
       resizable={false}
-      modal
+      modal={modal}
       closeOnEscape
-      dismissableMask
+      dismissableMask={dismissableMask}
       rtl={false}
       closable
-      maximizable={false}
-      blockScroll
-      keepInViewport
-      maximized={false}
+      maximizable={maximizable}
+      blockScroll={blockScroll}
+      keepInViewport={keepInViewport}
+      maximized={maximized}
       {...dataAttributes}
     >
       {children}

--- a/storybook/i18n/locales/stories/dialog/en.yml
+++ b/storybook/i18n/locales/stories/dialog/en.yml
@@ -11,6 +11,12 @@ props:
   showHeader: Whether to show the header or not.
   baseZIndex: Base zIndex value to use in layering.
   breakpoints: Object literal to define widths per screen size.
+  blockScroll: Whether background scroll should be blocked when dialog is visible.
+  maximizable: Whether the dialog can be displayed full screen.
+  keepInViewport: Keeps dialog in the viewport.
+  maximized: When enabled, the dialog is initially displayed full screen.
+  dismissableMask: Specifies if clicking the modal background should hide the dialog.
+  modal: Defines if background should be blocked when dialog is displayed.
   onHide: Callback to invoke when dialog is hidden (Required).
   onShow: Callback to invoke when dialog is showed.
   onClick: Callback to invoke when dialog is clicked.

--- a/storybook/stories/display/Dialog/dialog.js
+++ b/storybook/stories/display/Dialog/dialog.js
@@ -119,6 +119,12 @@ export const dialog = {
     { name: "showHeader", type: "boolean", default: true, description: `${I18N_PREFIX}.props.showHeader` },
     { name: "baseZIndex", type: "number", default: 100, description: `${I18N_PREFIX}.props.baseZIndex` },
     { name: "breakpoints", type: "object", description: `${I18N_PREFIX}.props.breakpoints` },
+    { name: "blockScroll", type: "boolean", default: true, description: `${I18N_PREFIX}.props.blockScroll` },
+    { name: "maximizable", type: "boolean", default: false, description: `${I18N_PREFIX}.props.maximizable` },
+    { name: "keepInViewport", type: "boolean", default: true, description: `${I18N_PREFIX}.props.keepInViewport` },
+    { name: "maximized", type: "boolean", default: false, description: `${I18N_PREFIX}.props.maximized` },
+    { name: "dismissableMask", type: "boolean", default: true, description: `${I18N_PREFIX}.props.dismissableMask` },
+    { name: "modal", type: "boolean", default: true, description: `${I18N_PREFIX}.props.modal` },
   ],
   eventDescriptionProps: [
     { name: "onHide", description: `${I18N_PREFIX}.props.onHide` },


### PR DESCRIPTION
Fix `Dialog` component:
- Remove `p-overflow-hidden` class when component unmounts. Otherwise scroll doesn't work when `Dialog` appears on mount
- Support more props