### PR TITLE
Fix money separator name

### DIFF
--- a/src/components/Money/index.js
+++ b/src/components/Money/index.js
@@ -2,10 +2,15 @@ import React, { Fragment } from "react"
 
 import { Number } from "../Number"
 
-const Money = ({ money: [amount, currency], precision = 2, moneySeparator = " ", ...options }) => {
+const Money = ({
+  money: [amount, currency],
+  precision = 2,
+  currencySeparator = " ",
+  ...options
+}) => {
   return (
     <Fragment>
-      <Number value={amount} {...options} precision={precision} />{moneySeparator}{currency}
+      <Number value={amount} {...options} precision={precision} />{currencySeparator}{currency}
     </Fragment>
   )
 }

--- a/storybook/i18n/locales/stories/money/en.yml
+++ b/storybook/i18n/locales/stories/money/en.yml
@@ -5,4 +5,4 @@ props:
   enforcePrecision: Do we need to enforce precision.
   delimiter: Delimiter for fractional portion.
   separator: Separator for thousands.
-  moneySeparator: Separator between amount and currency.
+  currencySeparator: Separator between amount and currency.

--- a/storybook/stories/display/Money/money.js
+++ b/storybook/stories/display/Money/money.js
@@ -18,14 +18,14 @@ function MoneyExample () {
         separator={" "}
       />
 
-      <h3>with moneySeparator</h3>
+      <h3>with currencySeparator</h3>
       <Money
         money={[1000.1000, "USD"]}
         precision={2}
         enforcePrecision
         delimiter={"."}
         separator={" "}
-        moneySeparator={"_"}
+        currencySeparator={"_"}
       />
     </div>
   )
@@ -45,6 +45,6 @@ export const money = {
     { name: "enforcePrecision", type: "boolean", default: false, description: `${I18N_PREFIX}.props.enforcePrecision` },
     { name: "delimiter", type: "string", default: ",", description: `${I18N_PREFIX}.props.delimiter` },
     { name: "separator", type: "string", default: "'\xA0'", description: `${I18N_PREFIX}.props.separator` },
-    { name: "moneySeparator", type: "string", default: "' '", description: `${I18N_PREFIX}.props.moneySeparator` },
+    { name: "currencySeparator", type: "string", default: "' '", description: `${I18N_PREFIX}.props.currencySeparator` },
   ],
 }


### PR DESCRIPTION
- Rename `moneySeparator` to `currencySeparator` in `Money` component