### PR TITLE
Fix: properly handle forwarded refs and fix dropdown collection cleanup logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/sphere-ui",
-  "version": "6.5.1",
+  "version": "6.5.2",
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
### Fixed

- Corrected unsafe usage of `ref || localRef` by introducing `useImperativeHandle` for better compatibility with both object and callback refs.
- Added `useEffect` cleanup to remove dropdown reference on component unmount.
- Fixed bug in `collections.remove()` where removed dropdowns were not actually excluded from internal list.
