### PR TITLE
Add viewDate support to DatePicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/sphere-ui",
-  "version": "6.9.1",
+  "version": "6.10.0",
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",

--- a/src/components/DatePicker/index.js
+++ b/src/components/DatePicker/index.js
@@ -51,11 +51,13 @@ export const DatePicker = React.forwardRef(({
   onShow,
   onHide,
   onVisibleChange,
+  viewDate,
+  onViewDateChange,
   utc,
   ...props
 }, ref) => {
   const defaultViewDate = value?.[0] || new Date()
-  const [viewDate, setViewDate] = useState(defaultViewDate)
+  const [customViewDate, setCustomViewDate] = useState(defaultViewDate)
   const dataAttributes = pickDataAttributes(props)
   const startDate = minDate || getTime(startCalendarDate, utc)
 
@@ -102,6 +104,8 @@ export const DatePicker = React.forwardRef(({
       onShow,
       onHide,
       onVisibleChange,
+      viewDate,
+      onViewDateChange,
       ...dataAttributes,
     }
   }
@@ -115,7 +119,7 @@ export const DatePicker = React.forwardRef(({
   }
 
   const onViewDateChangeCustom = e => {
-    setViewDate(e.value)
+    setCustomViewDate(e.value)
   }
 
   const renderDateRangePicker = () => {
@@ -126,7 +130,7 @@ export const DatePicker = React.forwardRef(({
         {...getDefaultProps()}
         rangeButtonsBar
         headerTemplate={headerTemplate}
-        viewDate={viewDate}
+        viewDate={customViewDate}
         onViewDateChange={onViewDateChangeCustom}
         numberOfMonths={2}
         startCalendarDate={startDate}
@@ -136,11 +140,11 @@ export const DatePicker = React.forwardRef(({
   }
 
   const headerTemplate = () => {
-    const month = viewDate.getMonth()
+    const month = customViewDate.getMonth()
     const nextMonth = month === 11 ? 0 : month + 1
     const monthName = MONTHS[primeLocale().locale][nextMonth]
 
-    const year = viewDate.getFullYear()
+    const year = customViewDate.getFullYear()
     const displayedYear = month === 11 ? year + 1 : year
 
     return (

--- a/storybook/i18n/locales/stories/datepicker/en.yml
+++ b/storybook/i18n/locales/stories/datepicker/en.yml
@@ -13,6 +13,7 @@ props:
   monthNavigator: Displays a dropdown with months.
   yearNavigator: Whether the year should be rendered as a dropdown instead of text.
   disabled: Disable the component.
+  viewDate: Date instance whose month and year are used to display the calendar in default mode.
   startRangeOfYears: Start year of years range.
   mask: Mask pattern for input element.
   minDate: The minimum selectable date.
@@ -43,5 +44,6 @@ props:
   onShow: Callback to invoke when overlay panel or modal becomes visible.
   onHide: Callback to invoke when overlay panel or modal becomes hidden.
   onVisibleChange: Callback to invoke when visible is changed.
+  onViewDateChange: Callback to invoke when the displayed month or year changes in default mode.
   utc: To change the start of the date with UTC format
   includeRangeButtons: "Array of preset buttons that will be displayed in range mode. By default all datepickers include values: \"today\", \"last24hours\", \"yesterday\", \"week\", \"last30days\", \"thisMonth\", \"lastMonth\", \"last180days\", \"allTime\", values may also be included: \"currentWeek\", \"nextWeek\", \"previousWeek\"."

--- a/storybook/stories/form/DatePicker/datePicker.js
+++ b/storybook/stories/form/DatePicker/datePicker.js
@@ -114,6 +114,11 @@ const onVisibleChangeParams = [
   { name: "callback", description: "It is used to refocus the input field in some cases when the overlay is hidden." },
 ]
 
+const onViewDateChangeParams = [
+  { name: "originalEvent", description: "Browser event" },
+  { name: "value", description: "New view date" },
+]
+
 export const datePicker = {
   component: "DatePicker",
   content: {
@@ -134,6 +139,7 @@ export const datePicker = {
     { name: "monthNavigator", type: "boolean", default: true, description: `${I18N_PREFIX}.props.monthNavigator` },
     { name: "yearNavigator", type: "boolean", default: true, description: `${I18N_PREFIX}.props.yearNavigator` },
     { name: "disabled", type: "boolean", default: false, description: `${I18N_PREFIX}.props.disabled` },
+    { name: "viewDate", type: "Date", default: null, description: `${I18N_PREFIX}.props.viewDate` },
     { name: "startRangeOfYears", type: "string", default: "2010", description: `${I18N_PREFIX}.props.startRangeOfYears` },
     { name: "mask", type: "string", default: null, description: `${I18N_PREFIX}.props.mask` },
     { name: "minDate", type: "Date", default: null, description: `${I18N_PREFIX}.props.minDate` },
@@ -169,5 +175,6 @@ export const datePicker = {
     { name: "onShow", description: `${I18N_PREFIX}.props.onShow` },
     { name: "onHide", description: `${I18N_PREFIX}.props.onHide` },
     { name: "onVisibleChange", params: onVisibleChangeParams, description: `${I18N_PREFIX}.props.onVisibleChange` },
+    { name: "onViewDateChange", params: onViewDateChangeParams, description: `${I18N_PREFIX}.props.onViewDateChange` },
   ],
 }


### PR DESCRIPTION
- Added `viewDate` and `onViewDateChange` passthrough props to `DatePicker`.
